### PR TITLE
Trim() kaldırıldı.

### DIFF
--- a/src/services/BilgeAdam.NTier.ERP.Service.Employees/EmployeeListService.cs
+++ b/src/services/BilgeAdam.NTier.ERP.Service.Employees/EmployeeListService.cs
@@ -35,8 +35,8 @@ namespace BilgeAdam.NTier.ERP.Service.Employees
 
         public List<EmployeeListDto> Search(string firstName, string lastName)
         {
-            return repo.Where(f => f.FirstName.StartsWith(firstName.Trim()) && 
-                                   f.LastName.StartsWith(lastName.Trim()))
+            return repo.Where(f => f.FirstName.StartsWith(firstName) && 
+                                   f.LastName.StartsWith(lastName))
                        .Select(s => new EmployeeListDto
                        {
                            FullName = s.FirstName + " " + s.LastName,


### PR DESCRIPTION
Eğer bir kişi sadece firstName veya lastName ile Search yapmak isterse, ilgili TextBox'ı boş bırakması yeterliydi ancak bu olayı çalıştıran koda daha sonradan Trim() methodunu ekledik ve artık textBox'ı boş bırakınca sorgu boş dönüyor. Sql sorgusuna da Trim methodu ekliyor Entity Framework, bununla alakalı olabilir.